### PR TITLE
Add ToggleMaximizeRestore action

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>socrates.tabshifter</id>
     <name>Tab Shifter</name>
-    <version>0.25</version>
+    <version>0.26</version>
     <vendor email="dmitry.kandalov@gmail.com" url="https://github.com/dkandalov/tab-shifter">Dmitry Kandalov</vendor>
 
     <description><![CDATA[
@@ -16,6 +16,7 @@
             <li>ctrl+alt+; - shift tab down</li>
             <li>alt+ctrl+[ - stretch split left</li>
             <li>alt+ctrl+] - stretch split right</li>
+            <li>alt+shift+M - maximize/restore split</li>
         </ul>
         Other OS shortcuts:
         <ul>
@@ -25,6 +26,7 @@
             <li>alt+shift+; - shift tab down</li>
             <li>ctrl+alt+[ - stretch split left</li>
             <li>ctrl+alt+] - stretch split right</li>
+            <li>alt+shift+M - maximize/restore split</li>
         </ul>
         To move focus between splits:
         <ul>
@@ -127,6 +129,13 @@
                 <keyboard-shortcut keymap="Mac OS X" first-keystroke="alt shift SEMICOLON" replace-all="true"/>
                 <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="alt shift SEMICOLON" replace-all="true"/>
             </action>
+
+            <action id="TabShiftActions.ToggleMaximizeRestore" class="tabshifter.Actions$ToggleMaximizeRestore" text="Minimize/Maximize Splitter">
+                <keyboard-shortcut keymap="$default" first-keystroke="alt shift M"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="alt shift M" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="alt shift M" replace-all="true"/>
+            </action>
+
         </group>
     </actions>
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ OSX shortcuts:
  - ``ctrl + alt + '`` - move tab to the split below (or create new split if it's the bottom split)
  - ``alt + shift + ['`` - stretch split left
  - ``alt + shift + ]'`` - stretch split right
+ - ``alt + shift + M`` - maximize/restore split
 
 Other OS shortcuts:
  - ``alt + shift + ]`` - move tab right
@@ -20,6 +21,7 @@ Other OS shortcuts:
  - ``alt + shift + '`` - move tab down
  - ``ctrl + alt + ['`` - stretch split left
  - ``ctrl + alt + ]'`` - stretch split right
+ - ``alt + shift + M`` - maximize/restore split
 
 To move focus between splits:
  - ``ctrl+alt+shift+]`` - right

--- a/plugin.groovy
+++ b/plugin.groovy
@@ -30,4 +30,6 @@ register("StretchLeft", "alt shift OPEN_BRACKET", "Stretch Splitter Left", new A
 register("StretchUp", "alt shift P", "Stretch Splitter Up", new Actions.StretchUp())
 register("StretchDown", "alt shift SEMICOLON", "Stretch Splitter Down", new Actions.StretchDown())
 
+register("ToggleMaximizeRestore", "alt shift M", "Maximize/Restore Splitter", new Actions.ToggleMaximizeRestore())
+
 show("Reloaded Tab Shifter plugin")

--- a/src/tabshifter/Actions.java
+++ b/src/tabshifter/Actions.java
@@ -74,13 +74,32 @@ public class Actions {
 		}
 	}
 
-	private static TabShifter tabShifter(AnActionEvent event) {
-		Project project = event.getProject();
-		FileEditorManagerEx editorManager = (project == null ? null : FileEditorManagerEx.getInstanceEx(project));
-		if (project == null || editorManager == null || editorManager.getAllEditors().length == 0) {
-			return TabShifter.none;
-		} else {
-			return new TabShifter(new Ide(editorManager, project));
+	public static class ToggleMaximizeRestore extends AnAction implements DumbAware {
+		@Override public void actionPerformed(AnActionEvent event) {
+			tabShifter(event).toggleMaximizeRestoreSplitter();
 		}
 	}
+
+	private static TabShifter tabShifter(AnActionEvent event) {
+		Project project = event.getProject();
+		if (project == null) {
+			return TabShifter.none;
+		}
+
+		// re-use old tabShifter to preserve state
+		if (projectTabShifter.containsKey(project.getProjectFilePath())) {
+			return projectTabShifter.get(project.getProjectFilePath());
+		}
+
+		FileEditorManagerEx editorManager = FileEditorManagerEx.getInstanceEx(project);
+		if (editorManager == null || editorManager.getAllEditors().length == 0) {
+			return TabShifter.none;
+		} else {
+			TabShifter tabShifter = new TabShifter(new Ide(editorManager, project));
+			projectTabShifter.put(project.getProjectFilePath(), tabShifter);
+			return tabShifter;
+		}
+	}
+
+	private static java.util.Map<String, TabShifter> projectTabShifter = new java.util.HashMap<String, TabShifter>();
 }

--- a/src/tabshifter/TabShifter.java
+++ b/src/tabshifter/TabShifter.java
@@ -123,6 +123,21 @@ public class TabShifter {
 		}
 	}
 
+	public void toggleMaximizeRestoreSplitter() {
+		LayoutElement layout = calculateAndSetPositions(ide.snapshotWindowLayout());
+		if (layout == LayoutElement.none) return;
+
+		Window window = currentWindowIn(layout);
+		Split split = findParentSplitOf(window, layout);
+		if (split == null) return;
+		boolean inFirst = split.first.equals(window);
+
+		boolean maximized = ide.toggleMaximizeRestoreSpliter(split, inFirst);
+		if (maximized) {
+			ide.hideToolWindows();
+		}
+	}
+
 	@Nullable private static Split findParentSplitOf(LayoutElement layoutElement, LayoutElement layout) {
 		for (Split split : allSplitsIn(layout)) {
 			if (split.first.equals(layoutElement) || split.second.equals(layoutElement)) {


### PR DESCRIPTION
This adds the ToggleMaximizeRestore action (Alt-Shift-M) which toggles the current editor inside a splitter between maximal and original proportion, giving a "fullscreen effect". On maximization, also the tool windows are hidden.