### PR TITLE
Target IntelliJ version 2025.2, fix #44

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,16 @@ sourceSets {
     }
 }
 
+// Disabled to avoid "java.lang.IndexOutOfBoundsException: Index: 1, Size: 1" during build
+tasks.named("buildSearchableOptions").configure {
+    enabled = false
+}
+
 intellij {
     // To find available IDE versions see https://www.jetbrains.com/intellij-repository/releases
     // and https://www.jetbrains.com/intellij-repository/snapshots
     version = System.getenv().getOrDefault("IJ_VERSION",
-        "2024.2" // Version with FileEditorOpenOptions signature change binary incompatibility
+        "2025.2"
 //        "LATEST-EAP-SNAPSHOT"
     )
     downloadSources = true

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -51,7 +51,7 @@
     ]]></description>
 
     <!-- See http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html -->
-    <idea-version since-build="242.2"/>
+    <idea-version since-build="252"/>
 
     <!-- See http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
     <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
Targeting IDE version 2025.2 seems to fix tabs disappearing when shifting into an existing tab pane.

I doubt this is the correct approach though. This is the first time I do anything with IntelliJ plugin SDK and also the first time in ~5 years I do anything JVM related. Anyhow, I decided to submit this in case this helps someone. Tab Shifter has been a core part of my editing workflow and this issue was driving me crazy 😂. Honestly I don't understand how the functionality provided by this plugin aren't builtin features.

Thank you for creating Tab Shifter!